### PR TITLE
fix: corrige o comportamento de cancelar/ encerrar projeto

### DIFF
--- a/ArchSpot-BackEnd/src/main/java/com/archspot/ArchSpot_BackEnd/services/ProjectService.java
+++ b/ArchSpot-BackEnd/src/main/java/com/archspot/ArchSpot_BackEnd/services/ProjectService.java
@@ -14,7 +14,9 @@ import com.archspot.ArchSpot_BackEnd.dtos.project.ProjectResponseDTO;
 import com.archspot.ArchSpot_BackEnd.dtos.userproject.UserProjectRequestDTO;
 import com.archspot.ArchSpot_BackEnd.entities.Phase;
 import com.archspot.ArchSpot_BackEnd.entities.Project;
+import com.archspot.ArchSpot_BackEnd.enums.PhaseStatus;
 import com.archspot.ArchSpot_BackEnd.enums.UserRole;
+import com.archspot.ArchSpot_BackEnd.exceptions.BusinessRuleException;
 import com.archspot.ArchSpot_BackEnd.repositories.ProjectRepository;
 import com.archspot.ArchSpot_BackEnd.security.SecurityUtils;
 
@@ -97,11 +99,32 @@ public class ProjectService {
   }
 
   // finalizar projeto
+  @Transactional
   public ProjectResponseDTO finalizeProject(Long id) {
     Project project = projectRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException("Projeto não encontrado: " + id));
+
+    List<Phase> phases = project.getPhases();
+
+    boolean temFasesNaoIniciadas = phases.stream()
+        .anyMatch(phase -> phase.getRealStartDate() == null);
+
+    if (temFasesNaoIniciadas) {
+      throw new BusinessRuleException(
+          "Não é possível finalizar um projeto com etapas não iniciadas.");
+    }
+
+    List<Long> fasesAEncerrar = phases.stream()
+        .filter(phase -> phase.getStatus() == PhaseStatus.IN_PROGRESS)
+        .map(Phase::getId)
+        .toList();
+
+    for (Long phaseId : fasesAEncerrar) {
+      phaseService.finishPhase(phaseId);
+    }
+    
+    project.updateDatesAndStatus();
     project.finalizeProject();
-    project.updateDatesAndStatus(); // redundante, melhorar no futuro
     return toResponseDTO(projectRepository.save(project));
   }
 
@@ -109,8 +132,8 @@ public class ProjectService {
   public ProjectResponseDTO cancelProject(Long id) {
     Project project = projectRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException("Projeto não encontrado: " + id));
+    project.updateDatesAndStatus();
     project.cancelProject();
-    project.updateDatesAndStatus(); // redundante, melhorar no futuro
     return toResponseDTO(projectRepository.save(project));
   }
 

--- a/archspot-angular/src/app/projects/pages/project-details-page/project-details-page.component.ts
+++ b/archspot-angular/src/app/projects/pages/project-details-page/project-details-page.component.ts
@@ -5,6 +5,7 @@ import { AuthService } from "../../../core/services/auth.service";
 import { Component, Inject } from "@angular/core";
 import { User } from "../../../core/models/user.model";
 import { ProjectResponse } from "../../../core/models/project.model";
+import { ToastService } from "../../../core/services/toast.service";
 
 @Component({
   selector: 'app-project-details-page',
@@ -29,7 +30,8 @@ export class ProjectDetailsPageComponent {
     private router: Router,
     private route: ActivatedRoute,
     private authService: AuthService,
-    private userProjectService: UserProjectService
+    private userProjectService: UserProjectService,
+    private toast: ToastService
   ) { }
 
   ngOnInit(): void {
@@ -71,7 +73,7 @@ export class ProjectDetailsPageComponent {
         this.loading = false;
       },
       error: (err) => {
-        console.error('Erro ao carregar projeto:', err);
+        this.toast.showError('Erro ao carregar projeto.');
         this.errorMessage = 'Erro ao carregar o projeto.';
         this.loading = false;
       }
@@ -98,7 +100,7 @@ export class ProjectDetailsPageComponent {
         this.project = updatedProject;
         this.editing = false;
       },
-      error: (err) => console.error('Erro ao atualizar projeto:', err)
+      error: (err) => this.toast.showError('Erro ao atualizar projeto.')
     });
   }
 
@@ -113,9 +115,9 @@ export class ProjectDetailsPageComponent {
     this.projectService.finalizeProject(this.project.id).subscribe({
       next: (updatedProject) => {
         this.project = updatedProject;
-        alert('Projeto finalizado com sucesso.');
+        this.toast.showSuccess('Projeto finalizado com sucesso.');
       },
-      error: (err) => console.error('Erro ao finalizar projeto:', err)
+      error: (err) => this.toast.showError('Erro ao finalizar projeto. ' + err.error)
     });
   }
 
@@ -125,9 +127,9 @@ export class ProjectDetailsPageComponent {
     this.projectService.cancelProject(this.project.id).subscribe({
       next: (updatedProject) => {
         this.project = updatedProject;
-        alert('Projeto cancelado com sucesso.');
+        this.toast.showSuccess('Projeto cancelado com sucesso.');
       },
-      error: (err) => console.error('Erro ao cancelar projeto:', err)
+      error: (err) => this.toast.showError('Erro ao cancelar projeto.')
     });
   }
 
@@ -139,10 +141,10 @@ export class ProjectDetailsPageComponent {
 
     this.projectService.deleteProject(this.project.id).subscribe({
       next: () => {
-        alert('Projeto excluído com sucesso.');
+        this.toast.showSuccess('Projeto excluído com sucesso.');
         this.router.navigate(['/projects']);
       },
-      error: (err) => console.error('Erro ao excluir projeto:', err)
+      error: (err) => this.toast.showError('Erro ao excluir projeto.')
     });
   }
 

--- a/archspot-angular/src/app/schedule/create-phase-modal/create-phase-modal.component.ts
+++ b/archspot-angular/src/app/schedule/create-phase-modal/create-phase-modal.component.ts
@@ -38,7 +38,7 @@ export class CreatePhaseModalComponent {
       estimatedStartDate: this.phaseEstimatedStartDate,
       estimatedEndDate: this.phaseEstimatedEndDate,
       projectId: this.projectId,
-      previousPhaseId: this.lastPhaseId || null
+      previousPhaseId: null // será melhor implementado no futuro
     };
 
     this.phaseService.createPhase(this.projectId, phaseData).subscribe({

--- a/archspot-angular/src/app/schedule/schedule.component.ts
+++ b/archspot-angular/src/app/schedule/schedule.component.ts
@@ -94,28 +94,21 @@ export class ScheduleComponent implements OnInit, AfterViewInit {
     if (this.isCustomerInProject) return false;
 
     const phase = this.phases[index];
-    if (phase.realStartDate || phase.status === 'IN_PROGRESS' || phase.status === 'COMPLETED') return false;
 
-    const start = new Date(phase.estimatedStartDate);
-    let prevId = phase.previousPhaseId || null;
-
-    while (prevId) {
-      const prev = this.phases.find(p => p.id === prevId);
-      if (!prev) return false;
-
-      if (prev.realEndDate) {
-        prevId = prev.previousPhaseId || null;
-        continue;
-      }
-
-      const prevStart = new Date(prev.estimatedStartDate);
-      const prevEnd = new Date(prev.estimatedEndDate);
-
-      if (start > prevStart && start <= prevEnd) return true;
+    // Não permitir iniciar fases já iniciadas ou concluídas
+    if (phase.realStartDate || phase.status === 'IN_PROGRESS' || phase.status === 'COMPLETED')
       return false;
-    }
 
-    return true;
+    const prevId = phase.previousPhaseId;
+
+    // Sem predecessora → pode iniciar
+    if (!prevId) return true;
+
+    // Com predecessora → precisa que a predecessora tenha iniciado
+    const prev = this.phases.find(p => p.id === prevId);
+    if (!prev) return true; // fallback seguro caso dados venham inconsistentes
+
+    return !!prev.realStartDate;
   }
 
   canFinishPhase(index: number): boolean {


### PR DESCRIPTION
close #135 - FINALMENTE

--- 

- corrige o comportamento das opções **cancelar**/ **finalizar** em Projeto;
- `cancelar`: 
  - apenas seta status `CANCELLED` no projeto e `realEndDate` para `.now()`;
  - pode ser revertido com qualquer edição de etapas;
- `finalizar`:
  - checa se existem etapas não iniciadas -> impede o encerramento
  - senão, atualiza todas as etapas para `COMPLETED` E `realEndDate` para `.now()`, atualiza o projeto com essas novas info automaticamente finalizando;
  - pode ser revertido com qualquer edição de etapas.

> [!IMPORTANT]
> Editei e simplifiquei bastante a lógica e restrições em Cronograma (etapas)! Estava dando muito conflito com o uso do `previousId`. Deixaremos isso para uma implementação futura.