### PR TITLE
Issue118/modais template e outros fixs

### DIFF
--- a/ArchSpot-BackEnd/src/main/java/com/archspot/ArchSpot_BackEnd/templates/services/TemplateService.java
+++ b/ArchSpot-BackEnd/src/main/java/com/archspot/ArchSpot_BackEnd/templates/services/TemplateService.java
@@ -35,15 +35,20 @@ public class TemplateService {
    */
 
   public List<ProjectTemplateDTO> findAllProjectTemplates() {
-    //mostrar tambem os templates de projeto default
     User currentUser = SecurityUtils.getCurrentUser();
+
     List<ProjectTemplate> userProjects = projectTemplateRepository.findAllByUserId(currentUser.getId());
     List<ProjectTemplate> defaultProjects = projectTemplateRepository.findByIsDefaultTrue();
 
-    return Stream.concat(userProjects.stream(), defaultProjects.stream())
-        .distinct()
-        .map(this::toProjectTemplateDTO)
-        .collect(Collectors.toList());
+    // filtra templates default que já foram clonados para o usuário (sugestao porque nao aparecia nenhum template)
+    List<ProjectTemplate> filteredDefaults = defaultProjects.stream()
+        .filter(dp -> userProjects.stream().noneMatch(up -> up.getName().equals(dp.getName())))
+        .toList();
+
+    List<ProjectTemplate> combined = Stream.concat(userProjects.stream(), filteredDefaults.stream())
+        .toList();
+
+    return combined.stream().map(this::toProjectTemplateDTO).toList();
   }
 
   public ProjectTemplateDTO findProjectTemplateById(Long id) {
@@ -101,14 +106,17 @@ public class TemplateService {
 
   public List<PhaseTemplateDTO> findAllPhaseTemplates() {
     User currentUser = SecurityUtils.getCurrentUser();
-    //mostrar tambem os templates de etapa default
     List<PhaseTemplate> userPhases = phaseTemplateRepository.findAllByUserId(currentUser.getId());
     List<PhaseTemplate> defaultPhases = phaseTemplateRepository.findByIsDefaultTrue();
 
-    return Stream.concat(userPhases.stream(), defaultPhases.stream())
-        .distinct()
+    // filtra templates default que já foram clonados para o usuário (sugestao porque nao aparecia nenhum template)
+    List<PhaseTemplate> filteredDefaults = defaultPhases.stream()
+        .filter(df -> userPhases.stream().noneMatch(up -> up.getName().equals(df.getName())))
+        .toList();
+
+    return Stream.concat(userPhases.stream(), filteredDefaults.stream())
         .map(this::toPhaseTemplateDTO)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   public PhaseTemplateDTO findPhaseTemplateById(Long id) {

--- a/ArchSpot-BackEnd/src/main/java/com/archspot/ArchSpot_BackEnd/templates/services/TemplateService.java
+++ b/ArchSpot-BackEnd/src/main/java/com/archspot/ArchSpot_BackEnd/templates/services/TemplateService.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class TemplateService {
@@ -34,11 +35,15 @@ public class TemplateService {
    */
 
   public List<ProjectTemplateDTO> findAllProjectTemplates() {
+    //mostrar tambem os templates de projeto default
     User currentUser = SecurityUtils.getCurrentUser();
-    return projectTemplateRepository.findAllByUserId(currentUser.getId())
-        .stream()
+    List<ProjectTemplate> userProjects = projectTemplateRepository.findAllByUserId(currentUser.getId());
+    List<ProjectTemplate> defaultProjects = projectTemplateRepository.findByIsDefaultTrue();
+
+    return Stream.concat(userProjects.stream(), defaultProjects.stream())
+        .distinct()
         .map(this::toProjectTemplateDTO)
-        .toList();
+        .collect(Collectors.toList());
   }
 
   public ProjectTemplateDTO findProjectTemplateById(Long id) {
@@ -96,10 +101,14 @@ public class TemplateService {
 
   public List<PhaseTemplateDTO> findAllPhaseTemplates() {
     User currentUser = SecurityUtils.getCurrentUser();
-    return phaseTemplateRepository.findAllByUserId(currentUser.getId())
-        .stream()
+    //mostrar tambem os templates de etapa default
+    List<PhaseTemplate> userPhases = phaseTemplateRepository.findAllByUserId(currentUser.getId());
+    List<PhaseTemplate> defaultPhases = phaseTemplateRepository.findByIsDefaultTrue();
+
+    return Stream.concat(userPhases.stream(), defaultPhases.stream())
+        .distinct()
         .map(this::toPhaseTemplateDTO)
-        .toList();
+        .collect(Collectors.toList());
   }
 
   public PhaseTemplateDTO findPhaseTemplateById(Long id) {

--- a/archspot-angular/src/app/about/about.component.html
+++ b/archspot-angular/src/app/about/about.component.html
@@ -32,10 +32,10 @@
         </li>
 
         <li [ngbNavItem]="'integrantes'">
-            <a ngbNavLink>Integrantes</a>
+            <a ngbNavLink>Desenvolvedores</a>
             <ng-template ngbNavContent>
                 <section class="p-4 fs-5 text-center">
-                    <h3 class="mb-4">Integrantes</h3>
+                    <h3 class="mb-4">Desenvolvedores</h3>
                     <div class="d-flex justify-content-center flex-wrap gap-4">
                         <a href="https://github.com/clararicioni" target="_blank" class="text-decoration-none text-dark integrante-card">
                             <div class="card p-3 shadow-sm" style="width: 150px;">

--- a/archspot-angular/src/app/core/models/phase-template.model.ts
+++ b/archspot-angular/src/app/core/models/phase-template.model.ts
@@ -1,0 +1,5 @@
+export interface PhaseTemplateDTO {
+  id?: number;
+  name: string;
+  defaultDurationDays: number;
+}

--- a/archspot-angular/src/app/core/models/project-template.model.ts
+++ b/archspot-angular/src/app/core/models/project-template.model.ts
@@ -1,0 +1,15 @@
+export interface PhaseTemplateDTO {
+  id?: number;
+  name: string;
+  description?: string;
+  defaultDurationDays?: number;
+}
+
+export interface ProjectTemplateDTO {
+  id?: number;
+  name: string;
+  description?: string;
+  phases?: PhaseTemplateDTO[];
+  createdBy?: number;
+  isDefault?: boolean;
+}

--- a/archspot-angular/src/app/core/services/template.service.ts
+++ b/archspot-angular/src/app/core/services/template.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { PhaseTemplateDTO, ProjectTemplateDTO } from '../models/project-template.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TemplateService {
+  private apiUrl = 'http://localhost:8080/templates';
+
+  constructor(private http: HttpClient) { }
+
+  getProjectTemplates(): Observable<ProjectTemplateDTO[]> {
+    return this.http.get<ProjectTemplateDTO[]>(`${this.apiUrl}/project`);
+  }
+
+  getProjectTemplateById(id: number): Observable<ProjectTemplateDTO> {
+    return this.http.get<ProjectTemplateDTO>(`${this.apiUrl}/project/${id}`);
+  }
+
+  createProjectTemplate(dto: ProjectTemplateDTO): Observable<ProjectTemplateDTO> {
+    return this.http.post<ProjectTemplateDTO>(`${this.apiUrl}/project`, dto);
+  }
+
+  getAllPhaseTemplates(): Observable<PhaseTemplateDTO[]> {
+    return this.http.get<PhaseTemplateDTO[]>(`${this.apiUrl}/phase`);
+  }
+
+  getPhaseTemplateById(id: number): Observable<PhaseTemplateDTO> {
+    return this.http.get<PhaseTemplateDTO>(`${this.apiUrl}/phase/${id}`);
+  }
+
+  createPhaseTemplate(dto: PhaseTemplateDTO): Observable<PhaseTemplateDTO> {
+    return this.http.post<PhaseTemplateDTO>(`${this.apiUrl}/phase`, dto);
+  }
+}

--- a/archspot-angular/src/app/home/pages/home-page/home-page.component.html
+++ b/archspot-angular/src/app/home/pages/home-page/home-page.component.html
@@ -19,8 +19,8 @@
     </app-section-title>
 
     <app-select-template-modal [show]="showModal" [currentUserId]="currentUserId" [currentUserName]="currentUserName"
-    (close)="showModal = false" (projectCreated)="loadUserProjects()">
-  </app-select-template-modal>
+      (close)="showModal = false" (projectCreated)="onProjectCreatedHandler()">
+    </app-select-template-modal>
 
     <div class="row g-4 row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-4 row-cols-xl-4 pb-3">
       <div class="col" *ngFor="let project of openProjects">

--- a/archspot-angular/src/app/home/pages/home-page/home-page.component.ts
+++ b/archspot-angular/src/app/home/pages/home-page/home-page.component.ts
@@ -85,4 +85,9 @@ export class HomePageComponent implements OnInit {
   openCreateProjectModal() {
     this.showModal = true;
   }
+
+  onProjectCreatedHandler() {
+    this.showModal = false;
+    this.loadUserProjects();
+  }
 }

--- a/archspot-angular/src/app/layout/sidebar-menu/sidebar-menu.component.html
+++ b/archspot-angular/src/app/layout/sidebar-menu/sidebar-menu.component.html
@@ -12,8 +12,6 @@
 
     <!-- menu do projeto -->
     <ng-container *ngIf="activeProject">
-      <li class="fw-semibold text-secondary mb-2">{{ activeProject.name }}</li>
-
       <li *ngFor="let item of projectMenuItems" class="mb-3">
         <a (click)="goToProjectSubItem(item.key)" role="button"
           class="d-flex align-items-center link-dark link-opacity-50-hover link-underline-opacity-0 fs-5">

--- a/archspot-angular/src/app/payments/edit-installment-modal/edit-installment-modal.component.html
+++ b/archspot-angular/src/app/payments/edit-installment-modal/edit-installment-modal.component.html
@@ -5,7 +5,7 @@
 
     <div class="mb-3">
       <label class="form-label">Valor</label>
-      <input type="text" placeholder="Valor da parcela" [ngModel]="cloned.amount" class="form-control" (input)="onAmountChange($event)" />
+      <input type="text" placeholder="Valor da parcela" [(ngModel)]="cloned.amount" class="form-control" (input)="onAmountChange($event)" />
     </div>
 
     <div class="mb-3">

--- a/archspot-angular/src/app/payments/edit-installment-modal/edit-installment-modal.component.ts
+++ b/archspot-angular/src/app/payments/edit-installment-modal/edit-installment-modal.component.ts
@@ -37,14 +37,13 @@ export class EditInstallmentModalComponent implements OnChanges {
   }
 
   onAmountChange(event: Event) {
-    const input = event.target as HTMLInputElement | null;
+    const input = event.target as HTMLInputElement;
     if (!input) return;
 
-    const value = input.value;
+    const value = input.value.replace(/\D/g, '');
+    const numeric = Number(value) / 100;
 
-    const onlyNumbers = value.replace(/\D/g, '');
-    const numeric = Number(onlyNumbers) / 100;
-    this.amount = numeric;
+    this.cloned.amount = numeric;
 
     input.value = numeric.toLocaleString('pt-BR', {
       minimumFractionDigits: 2,

--- a/archspot-angular/src/app/projects/pages/projects-page/projects-page.component.html
+++ b/archspot-angular/src/app/projects/pages/projects-page/projects-page.component.html
@@ -16,7 +16,7 @@
   </div>
 
   <app-select-template-modal [show]="showModal" [currentUserId]="currentUserId" [currentUserName]="currentUserName"
-    (close)="showModal = false" (projectCreated)="loadUserProjects()">
+    (close)="showModal = false" (projectCreated)="onProjectCreatedHandler()">
   </app-select-template-modal>
 
   <ng-container *ngIf="!loading && !errorMessage">

--- a/archspot-angular/src/app/projects/pages/projects-page/projects-page.component.ts
+++ b/archspot-angular/src/app/projects/pages/projects-page/projects-page.component.ts
@@ -85,4 +85,9 @@ export class ProjectsPageComponent implements OnInit {
   openModal(): void {
     this.showModal = true;
   }
+
+  onProjectCreatedHandler() {
+    this.showModal = false;
+    this.loadUserProjects();
+  }
 }

--- a/archspot-angular/src/app/shared/components/project-status-bar/project-status-bar.component.css
+++ b/archspot-angular/src/app/shared/components/project-status-bar/project-status-bar.component.css
@@ -70,12 +70,12 @@
   background-color: #ffc107;
 }
 
-.timeline-dot.not-started {
-  background-color: #ccc;
+.timeline-dot.in-progress-overdue {
+  background-color: #dc3545;
 }
 
-.timeline-dot.overdue {
-  background-color: #dc3545;
+.timeline-dot.not-started {
+  background-color: #ccc;
 }
 
 .timeline-label-top {

--- a/archspot-angular/src/app/shared/components/project-status-bar/project-status-bar.component.html
+++ b/archspot-angular/src/app/shared/components/project-status-bar/project-status-bar.component.html
@@ -8,12 +8,7 @@
 
     <div class="timeline-item" *ngFor="let phase of phases; let i = index">
       <div class="timeline-label-top">
-        <div class="timeline-dot" [ngClass]="{
-                                  'completed': i <= lastCompletedIndex,
-                                  'in-progress': phase.status === 'IN_PROGRESS',
-                                  'overdue': phase.status === 'OVERDUE',
-                                  'not-started': phase.status === 'NOT_STARTED'
-        }">
+        <div class="timeline-dot" [ngClass]="getDotClass(phase)">
         </div>
         <span class="phase-name">{{ phase.name }}</span><br>
         <span class="phase-date">{{ phase.estimatedStartDate | date:'dd/MM' }}</span>

--- a/archspot-angular/src/app/shared/components/project-status-bar/project-status-bar.component.ts
+++ b/archspot-angular/src/app/shared/components/project-status-bar/project-status-bar.component.ts
@@ -18,7 +18,7 @@ export class ProjectStatusBarComponent implements OnInit, AfterViewInit {
     private phaseService: PhaseService,
     private elRef: ElementRef,
     private router: Router
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     if (!this.projectId) {
@@ -43,16 +43,44 @@ export class ProjectStatusBarComponent implements OnInit, AfterViewInit {
   loadPhases(): void {
     this.phaseService.getPhasesByProjectId(this.projectId).subscribe({
       next: (phases) => {
-        this.phases = phases.map(p => ({
-          ...p,
-          estimatedStartDate: new Date(p.estimatedStartDate),
-          estimatedEndDate: new Date(p.estimatedEndDate)
-        }));
+        const today = new Date();
+
+        this.phases = phases.map(p => {
+          const estimatedEnd = new Date(p.estimatedEndDate);
+          const realStart = p.realStartDate ? new Date(p.realStartDate) : null;
+          const realEnd = p.realEndDate ? new Date(p.realEndDate) : null;
+
+          let status = 'NOT_STARTED';
+          if (realEnd) status = 'COMPLETED';
+          else if (realStart) status = 'IN_PROGRESS';
+          else if (estimatedEnd < today) status = 'OVERDUE';
+
+          return {
+            ...p,
+            estimatedEndDate: estimatedEnd,
+            realStartDate: realStart,
+            realEndDate: realEnd,
+            status
+          };
+        });
+
         this.updateProgressLine();
       },
       error: (err) => console.error('Erro ao carregar fases do projeto', err)
     });
   }
+
+  getDotClass(phase: any): string {
+  const now = new Date().getTime();
+  const estimatedEnd = new Date(phase.estimatedEndDate).getTime();
+
+  if (phase.status === 'COMPLETED') return 'completed'; 
+  if (phase.status === 'IN_PROGRESS') {
+    //console.log(estimatedEnd < now ? 'in-progress-overdue' : 'in-progress');
+    return estimatedEnd < now ? 'in-progress-overdue' : 'in-progress';
+  }
+  return 'not-started';
+}
 
   updateProgressLine(): void {
     if (!this.phases.length) {

--- a/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.css
+++ b/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.css
@@ -52,6 +52,7 @@
 
 .etapa-btn:hover {
   transform: translateY(-1px);
+  cursor: default;
 }
 
 .etapa-duracao {
@@ -62,7 +63,6 @@
 
 .etapa-duracao input {
   width: 70px;
-  /* 🔹 menor e mais discreto */
   padding: 3px 6px;
   font-size: 0.85rem;
   text-align: center;
@@ -72,7 +72,6 @@
   border-color: #28a745;
 }
 
-/* 🔹 Colaboradores */
 .collaborators-container {
   max-height: 400px;
   min-height: 150px;

--- a/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.html
+++ b/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.html
@@ -1,7 +1,11 @@
 <!-- CRIANDO UM NOVO PROJETO -->
 <div class="modal-overlay" *ngIf="show" (click)="onCancel()">
   <div class="modal-content" (click)="$event.stopPropagation()">
-    <h4 class="modal-title font-logo">Criar Novo Projeto</h4>
+    <div class="modal-header">
+      <h4 class="modal-title font-logo">Criar Novo Projeto - {{ templateName }} </h4>
+      <button type="button" class="btn-close" (click)="close.emit()"></button>
+    </div>
+
     <hr />
 
     <label class="fs-6 fw-semibold modal-label2">Nome</label>
@@ -17,10 +21,7 @@
 
     <div class="etapas-container mb-4">
       <div class="etapa-item" *ngFor="let etapa of etapas" [ngClass]="{ selected: isSelected(etapa.nome) }">
-        <button type="button" class="btn btn-sm etapa-btn" [ngClass]="{
-            'btn-success': isSelected(etapa.nome),
-            'btn-outline-success': !isSelected(etapa.nome)
-          }" (click)="toggleEtapa(etapa.nome)">
+        <button type="button" class="btn btn-success etapa-btn p-2">
           {{ etapa.nome }}
         </button>
 
@@ -76,8 +77,11 @@
       </ng-template>
     </div>
 
-    <div class="modal-actions">
-      <button class="btn btn-secondary" (click)="onCancel()">Editar Etapas</button>
+    <div class="modal-actions d-flex justify-content-end">
+      <button class="btn btn-secondary" (click)="onGoBack()">
+        Voltar
+      </button>
+      <button class="btn btn-secondary me-2" (click)="editPhases.emit(etapas)">Editar Etapas</button>
       <button class="btn btn-success" (click)="createProject()">Criar Projeto</button>
     </div>
   </div>

--- a/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.html
+++ b/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.html
@@ -1,9 +1,8 @@
-<!-- CRIANDO UM NOVO PROJETO -->
 <div class="modal-overlay" *ngIf="show" (click)="onCancel()">
   <div class="modal-content" (click)="$event.stopPropagation()">
     <div class="modal-header">
       <h4 class="modal-title font-logo">Criar Novo Projeto - {{ templateName }} </h4>
-      <button type="button" class="btn-close" (click)="close.emit()"></button>
+      <button type="button" class="btn-close" (click)="onGoBack()"></button>
     </div>
 
     <hr />

--- a/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.ts
+++ b/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.ts
@@ -47,7 +47,6 @@ export class ConfirmCreateNewProjectModalComponent implements OnChanges {
         nome: p.name,
         duracao: p.duration
       }));
-
       this.etapasSelecionadas = this.etapas.map(e => e.nome);
     }
   }
@@ -165,6 +164,6 @@ export class ConfirmCreateNewProjectModalComponent implements OnChanges {
   }
 
   onCancel() {
-    this.editPhases.emit(this.etapas);
+    this.goBack.emit();
   }
 }

--- a/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.ts
+++ b/archspot-angular/src/app/templates/confirm-create-new-project/confirm-create-new-project.component.ts
@@ -1,5 +1,8 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { UserResponse } from '../../core/services/search-user.service';
+import { ProjectService } from '../../core/services/project.service';
+import { PhaseService } from '../../core/services/phase.service';
+import { CreateProjectRequest } from '../../core/models/project.model';
 
 interface Etapa {
   nome: string;
@@ -11,85 +14,157 @@ interface Etapa {
   templateUrl: './confirm-create-new-project.component.html',
   styleUrls: ['./confirm-create-new-project.component.css']
 })
-export class ConfirmCreateNewProjectModalComponent {
+export class ConfirmCreateNewProjectModalComponent implements OnChanges {
   @Input() show = false;
+  @Input() templateId?: number;
+  @Input() templatePhases?: { name: string; duration: number }[];
+  @Input() templateName: string = '';
+
   @Output() close = new EventEmitter<void>();
   @Output() created = new EventEmitter<void>();
-  @Output() editPhases = new EventEmitter<void>();
+  @Output() editPhases = new EventEmitter<Etapa[]>();
+  @Output() goBack = new EventEmitter<void>();
 
   projectName = '';
   projectDescription = '';
   estimatedStartDate = '';
 
-  etapas: Etapa[] = [
-    { nome: 'Estudo Preliminar', duracao: 5 },
-    { nome: 'Anteprojeto', duracao: 5 },
-    { nome: 'Projeto Legal', duracao: 5 },
-    { nome: 'Projeto Executivo', duracao: 5 }
-  ];
-
+  etapas: Etapa[] = [];
   etapasSelecionadas: string[] = [];
 
   roles: string[] = ['STAFF', 'CUSTOMER', 'EXTERNAL_COLLABORATOR'];
   showAddModal = false;
   users: { id: number; name: string; role: string }[] = [];
 
-  onCancel() {
-    this.editPhases.emit();
-  }
+  constructor(
+    private projectService: ProjectService,
+    private phaseService: PhaseService
+  ) { }
 
-  toggleEtapa(etapaNome: string) {
-    if (this.etapasSelecionadas.includes(etapaNome)) {
-      this.etapasSelecionadas = this.etapasSelecionadas.filter(e => e !== etapaNome);
-    } else {
-      this.etapasSelecionadas.push(etapaNome);
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['templatePhases'] && this.templatePhases) {
+      this.etapas = this.templatePhases.map(p => ({
+        nome: p.name,
+        duracao: p.duration
+      }));
+
+      this.etapasSelecionadas = this.etapas.map(e => e.nome);
     }
   }
 
-  isSelected(etapaNome: string): boolean {
-    return this.etapasSelecionadas.includes(etapaNome);
+  onGoBack() {
+    this.goBack.emit();
   }
 
-  openAddUserModal() {
-    this.showAddModal = true;
+  toggleEtapa(nome: string) {
+    if (this.etapasSelecionadas.includes(nome)) {
+      this.etapasSelecionadas = this.etapasSelecionadas.filter(x => x !== nome);
+    } else {
+      this.etapasSelecionadas.push(nome);
+    }
   }
 
-  cancelAdd() {
-    this.showAddModal = false;
+  isSelected(nome: string) {
+    return this.etapasSelecionadas.includes(nome);
   }
+
+  openAddUserModal() { this.showAddModal = true; }
+  cancelAdd() { this.showAddModal = false; }
 
   handleAddUser(data: { user: UserResponse; role: string }) {
-    const userObj = {
-      id: data.user.id,
-      name: data.user.name,
-      role: data.role
-    };
-    if (!this.users.find(u => u.id === userObj.id)) {
-      this.users.push(userObj);
-    }
+    const obj = { id: data.user.id, name: data.user.name, role: data.role };
+    if (!this.users.find(u => u.id === obj.id)) this.users.push(obj);
   }
 
-  removeUser(userId: number) {
-    this.users = this.users.filter(u => u.id !== userId);
+  removeUser(id: number) {
+    this.users = this.users.filter(u => u.id !== id);
   }
 
   createProject() {
     if (!this.projectName.trim()) {
-      alert('Digite um nome para o projeto.');
+      alert("Digite um nome para o projeto.");
+      return;
+    }
+    if (!this.estimatedStartDate) {
+      alert("Selecione a data de início estimada.");
       return;
     }
 
-    const etapasSelecionadasDetalhes = this.etapas
-      .filter(e => this.etapasSelecionadas.includes(e.nome))
-      .map(e => ({ nome: e.nome, duracao: e.duracao }));
+    const etapasSelecionadas = this.etapas.filter(
+      e => this.etapasSelecionadas.includes(e.nome)
+    );
 
-    console.log('Novo projeto criado:', {
-      nome: this.projectName,
-      descricao: this.projectDescription,
-      etapas: etapasSelecionadasDetalhes,
-      equipe: this.users
+    if (etapasSelecionadas.length === 0) {
+      alert("Selecione pelo menos uma etapa.");
+      return;
+    }
+
+    const payload: CreateProjectRequest = {
+      name: this.projectName,
+      description: this.projectDescription,
+      estimatedStartDate: this.estimatedStartDate,
+      templateId: this.templateId
+    } as any;
+
+    this.projectService.createProject(payload).subscribe({
+      next: project => {
+        const projectId = project.id;
+
+        this.users.forEach(u =>
+          this.projectService.assignUserToProject(projectId, u.id, u.role).subscribe()
+        );
+        this.createPhasesSequentially(projectId, etapasSelecionadas);
+
+      },
+      error: err => {
+        console.error(err);
+        alert("Erro ao criar projeto.");
+      }
     });
+  }
 
-    this.created.emit();
+  private createPhasesSequentially(projectId: number, etapas: Etapa[]) {
+    let current = new Date(this.estimatedStartDate);
+    let lastPhaseId: number | null = null;
+
+    const createNext = (index: number) => {
+      if (index >= etapas.length) {
+        this.created.emit();
+        return;
+      }
+
+      const etapa = etapas[index];
+
+      const start = new Date(current);
+      const end = new Date(start);
+      end.setDate(start.getDate() + (etapa.duracao ?? 1));
+
+      const phaseBody = {
+        name: etapa.nome,
+        description: '',
+        estimatedStartDate: start.toISOString().split("T")[0],
+        estimatedEndDate: end.toISOString().split("T")[0],
+        previousPhaseId: lastPhaseId
+      };
+
+      this.phaseService.createPhase(projectId, phaseBody).subscribe({
+        next: createdPhase => {
+          lastPhaseId = createdPhase.id;
+          current = new Date(end);
+          current.setDate(current.getDate() + 1);
+
+          createNext(index + 1);
+        },
+        error: err => {
+          console.error("Erro ao criar fase:", etapa.nome, err);
+        }
+      });
+    };
+
+    createNext(0);
+  }
+
+  onCancel() {
+    this.editPhases.emit(this.etapas);
   }
 }

--- a/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.html
+++ b/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.html
@@ -1,8 +1,7 @@
-<!-- MODAL PARA CRIAR NOVO TEMPLATE, SEM CRIAR UM PROJETO -->
 <div class="modal fade show" *ngIf="show" tabindex="-1" style="display:block; background-color: rgba(0,0,0,0.5);">
   <div class="modal-dialog">
     <div class="modal-content">
-      
+
       <div class="modal-header">
         <h1 class="modal-title fs-4 font-logo">Criar Novo Template</h1>
         <button type="button" class="btn-close" (click)="onCancel()" aria-label="Close"></button>
@@ -14,8 +13,8 @@
             <form class="col">
               <div class="mb-3">
                 <label for="campoNome" class="form-label">Nome do template:</label>
-                <input type="text" class="form-control" id="campoNome" [(ngModel)]="templateName"
-                  name="templateName" placeholder="Digite o nome do template" />
+                <input type="text" class="form-control" id="campoNome" [(ngModel)]="templateName" name="templateName"
+                  placeholder="Digite o nome do template" />
               </div>
 
               <div class="row mb-3">

--- a/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.html
+++ b/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.html
@@ -1,48 +1,46 @@
 <!-- MODAL PARA CRIAR NOVO TEMPLATE, SEM CRIAR UM PROJETO -->
 <div class="modal fade show" *ngIf="show" tabindex="-1" style="display:block; background-color: rgba(0,0,0,0.5);">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h1 class="modal-title fs-4 font-logo">Criar Novo Template</h1>
-                <button type="button" class="btn-close" (click)="onCancel()" aria-label="Close"></button>
-            </div>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      
+      <div class="modal-header">
+        <h1 class="modal-title fs-4 font-logo">Criar Novo Template</h1>
+        <button type="button" class="btn-close" (click)="onCancel()" aria-label="Close"></button>
+      </div>
 
-            <div class="modal-body">
-                <div class="container-fluid">
-                    <div class="row g-3 fw-medium">
-                        <form class="col">
-                            <div class="mb-3">
-                                <label for="campoNome" class="form-label">Nome do template:</label>
-                                <input type="text" class="form-control" id="campoNome" [(ngModel)]="templateName"
-                                    name="templateName" placeholder="Digite o nome do template" />
-                            </div>
+      <div class="modal-body">
+        <div class="container-fluid">
+          <div class="row g-3 fw-medium">
+            <form class="col">
+              <div class="mb-3">
+                <label for="campoNome" class="form-label">Nome do template:</label>
+                <input type="text" class="form-control" id="campoNome" [(ngModel)]="templateName"
+                  name="templateName" placeholder="Digite o nome do template" />
+              </div>
 
-                            <div class="row mb-3">
-                                <div class="col-3">
-                                    <label class="form-label">Etapas:</label>
-                                </div>
-                                <div class="col-9">
-                                    <div class="d-grid gap-1">
-                                        <button type="button" class="btn btn-outline-success text-start">Estudo
-                                            Preliminar</button>
-                                        <button type="button"
-                                            class="btn btn-outline-success text-start">Anteprojeto</button>
-                                        <button type="button" class="btn btn-outline-success text-start">Projeto
-                                            Legal</button>
-                                        <button type="button" class="btn btn-outline-success text-start">Projeto
-                                            Executivo</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </form>
-                    </div>
+              <div class="row mb-3">
+                <div class="col-3">
+                  <label class="form-label">Etapas:</label>
                 </div>
-            </div>
-
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" (click)="onCancel()">Voltar para Etapas</button>
-                <button type="button" class="btn btn-success" (click)="onSave()">Salvar Template</button>
-            </div>
+                <div class="col-9">
+                  <div class="d-grid gap-1">
+                    <button *ngFor="let phase of selectedPhases" type="button"
+                      class="btn btn-outline-success text-start" disabled>
+                      {{ phase.name }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
         </div>
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" (click)="onCancel()">Voltar para Etapas</button>
+        <button type="button" class="btn btn-success" (click)="onSave()">Salvar Template</button>
+      </div>
+
     </div>
+  </div>
 </div>

--- a/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.ts
@@ -40,9 +40,13 @@ export class ConfirmCreateNewTemplateModalComponent {
     };
 
     this.templateService.createProjectTemplate(template).subscribe({
-      next: savedTemplate => this.saved.emit(savedTemplate),
-      error: err => console.error('Erro ao salvar template', err)
+      next: savedTemplate => {
+        this.saved.emit(savedTemplate); // Retorna o template salvo para o NewProjectTemplateModal
+      },
+      error: err => {
+        console.error('Erro ao salvar template', err);
+        this.saving = false;
+      }
     });
-
   }
 }

--- a/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/confirm-create-new-template-modal/confirm-create-new-template-modal.component.ts
@@ -1,4 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { TemplateService } from '../../core/services/template.service';
+import { PhaseTemplateDTO, ProjectTemplateDTO } from '../../core/models/project-template.model';
 
 @Component({
   selector: 'app-confirm-create-new-template-modal',
@@ -7,10 +9,14 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export class ConfirmCreateNewTemplateModalComponent {
   @Input() show = false;
+  @Input() selectedPhases: PhaseTemplateDTO[] = [];
   @Output() close = new EventEmitter<void>();
-  @Output() saved = new EventEmitter<void>();
+  @Output() saved = new EventEmitter<ProjectTemplateDTO>();
 
   templateName = '';
+  saving = false;
+
+  constructor(private templateService: TemplateService) { }
 
   onCancel() {
     this.close.emit();
@@ -21,7 +27,22 @@ export class ConfirmCreateNewTemplateModalComponent {
       alert('Por favor, insira um nome para o template.');
       return;
     }
-    console.log('Template salvo:', this.templateName);
-    this.saved.emit();
+
+    this.saving = true;
+
+    const template: ProjectTemplateDTO = {
+      name: this.templateName.trim(),
+      description: undefined,
+      phases: this.selectedPhases,
+      createdBy: undefined,
+      isDefault: false,
+      id: undefined
+    };
+
+    this.templateService.createProjectTemplate(template).subscribe({
+      next: savedTemplate => this.saved.emit(savedTemplate),
+      error: err => console.error('Erro ao salvar template', err)
+    });
+
   }
 }

--- a/archspot-angular/src/app/templates/new-phase-template-modal/new-phase-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/new-phase-template-modal/new-phase-template-modal.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { PhaseTemplateDTO } from '../../core/models/project-template.model';
 
 @Component({
   selector: 'app-new-phase-template-modal',
@@ -8,7 +9,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 export class NewPhaseTemplateModalComponent {
   @Input() show = false;
   @Output() close = new EventEmitter<void>();
-  @Output() save = new EventEmitter<{ name: string; duration: number }>();
+  @Output() save = new EventEmitter<PhaseTemplateDTO>();
 
   phaseName = '';
   phaseDuration: number | null = null;
@@ -19,7 +20,10 @@ export class NewPhaseTemplateModalComponent {
 
   onSave() {
     if (!this.phaseName.trim() || !this.phaseDuration) return;
-    this.save.emit({ name: this.phaseName.trim(), duration: this.phaseDuration });
+    this.save.emit({
+      name: this.phaseName.trim(),
+      defaultDurationDays: this.phaseDuration,
+    });
     this.onClose();
   }
 }

--- a/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.html
+++ b/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.html
@@ -1,69 +1,77 @@
-<!-- CRIAÇÃO DE NOVO PROJETO -->
-<div class="modal fade show" tabindex="-1" role="dialog" *ngIf="show && !showConfirmCreateProjectModal"
+<!-- MODAL DE CRIAR NOVO PROJETO / EDITAR TEMPLATE -->
+<div class="modal fade show" tabindex="-1" role="dialog" *ngIf="show || showConfirmCreateProjectModal"
   style="display:block; background-color: rgba(0,0,0,0.5);">
-  <div class="modal-dialog modal-lg">
+  <div class="modal-dialog">
     <div class="modal-content">
+
       <div class="modal-header">
-        <h1 class="modal-title fs-4 font-logo">Criar Novo Projeto</h1>
-        <button type="button" class="btn-close" (click)="closeModal()" aria-label="Close"></button>
+        <h1 class="modal-title fs-4 font-logo">
+          {{ editing ? 'Editar Etapas do Projeto' : 'Criar Novo Projeto' }}
+        </h1>
+        <button type="button" class="btn-close" (click)="close.emit()"></button>
       </div>
 
       <div class="modal-body">
-        <div class="container-fluid">
-          <div class="row g-3">
+        <div class="row g-3">
 
-            <div class="col-sm-6">
-              <h5>Outras etapas:</h5>
-              <div class="d-grid gap-1">
-                <button type="button" class="btn btn-outline-secondary shadow text-start mb-2">As Built</button>
-                <button type="button" class="btn btn-outline-secondary shadow text-start mb-2">Detalhamento</button>
-                <button type="button" class="btn btn-outline-secondary shadow text-start mb-2">Levantamento</button>
-                <button type="button" class="btn btn-outline-secondary shadow text-start mb-2">Mobiliário</button>
-                <button type="button" class="btn btn-outline-secondary shadow text-start mb-2">Interiores</button>
-              </div>
-            </div>
-
-            <div class="col-sm-6">
-              <h5>Etapas no projeto:</h5>
-              <div class="d-grid gap-1">
-                <button type="button" class="btn mb-2 btn-outline-success shadow text-start">Estudo Preliminar</button>
-                <button type="button" class="btn mb-2 btn-outline-success shadow text-start">Anteprojeto</button>
-                <button type="button" class="btn mb-2 btn-outline-success shadow text-start">Projeto Legal</button>
-                <button type="button" class="btn mb-2 btn-outline-success shadow text-start">Projeto Executivo</button>
-              </div>
+          <div class="col-sm-6">
+            <h5>Outras etapas:</h5>
+            <div class="d-grid gap-1">
+              <button *ngFor="let phase of otherPhases" type="button"
+                class="btn btn-outline-secondary shadow text-start mb-2" (click)="addPhaseToProject(phase)">
+                {{ phase.name }}
+              </button>
             </div>
           </div>
 
-          <div class="row">
-            <div class="col d-grid">
-              <button type="button" class="btn btn-outline-secondary mt-5 mb-2" (click)="openNewPhaseModal()">
-                + Criar Nova Etapa
-              </button>
-              <button type="button" class="btn btn-outline-success" (click)="saveTemplate()">
-                Salvar Template
+          <div class="col-sm-6">
+            <h5>Etapas no projeto:</h5>
+            <div class="d-grid gap-1">
+              <button *ngFor="let phase of projectPhases" type="button"
+                class="btn mb-2 btn-outline-success shadow text-start" (click)="removePhaseFromProject(phase)">
+                {{ phase.name }}
               </button>
             </div>
           </div>
         </div>
+
+        <div class="row mt-4">
+          <div class="col d-grid">
+            <button type="button" class="btn btn-outline-secondary" (click)="openNewPhaseModal()">
+              + Criar Nova Etapa
+            </button>
+          </div>
+        </div>
+
       </div>
 
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" (click)="goBack()">Voltar para Templates</button>
-        <button type="button" class="btn btn-success" (click)="openConfirmCreateProject()">Criar Projeto</button>
+        <button *ngIf="returnToProjectConfirm" type="button" class="btn btn-secondary" (click)="goBackModal()">
+          Voltar
+        </button>
+
+        <button *ngIf="!editing" type="button" class="btn btn-success" (click)="openConfirmCreateProject()">
+          Criar Projeto
+        </button>
+
+        <button *ngIf="editing" type="button" class="btn btn-success" (click)="saveTemplate()">
+          Salvar alterações
+        </button>
       </div>
     </div>
   </div>
 </div>
 
-<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" (close)="onCancelConfirm()"
-  (created)="onProjectCreated()"></app-confirm-create-new-project-modal>
-
+<!-- MODAIS INTERNAS -->
 <app-new-phase-template-modal [show]="showNewPhaseModal" (close)="onCloseNewPhaseModal()"
-  (save)="onSaveNewPhase($event)"></app-new-phase-template-modal>
+  (save)="onSaveNewPhase($event)">
+</app-new-phase-template-modal>
 
-<app-confirm-create-new-template-modal [show]="showConfirmCreateTemplateModal" (close)="onCancelConfirmTemplate()"
-  (saved)="onTemplateSaved()"></app-confirm-create-new-template-modal>
-
-<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" (close)="onCancelConfirm()"
-  (created)="onProjectCreated()" (editPhases)="onEditPhases()">
+<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" [templatePhases]="templatePhasesForConfirm"
+  (close)="onCancelConfirm()" (created)="onProjectCreated()" (goBack)="showConfirmCreateProjectModal = true"
+  (editPhases)="editPhasesForProject()">
 </app-confirm-create-new-project-modal>
+
+<app-confirm-create-new-template-modal [show]="showConfirmCreateTemplateModal" [selectedPhases]="projectPhases"
+  (close)="onCancelConfirmTemplate()" (saved)="onTemplateSaved($event)">
+</app-confirm-create-new-template-modal>

--- a/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.html
+++ b/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.html
@@ -1,5 +1,4 @@
-<!-- MODAL DE CRIAR NOVO PROJETO / EDITAR TEMPLATE -->
-<div class="modal fade show" tabindex="-1" role="dialog" *ngIf="show || showConfirmCreateProjectModal"
+<div class="modal fade show" tabindex="-1" role="dialog" *ngIf="show"
   style="display:block; background-color: rgba(0,0,0,0.5);">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -8,7 +7,7 @@
         <h1 class="modal-title fs-4 font-logo">
           {{ editing ? 'Editar Etapas do Projeto' : 'Criar Novo Projeto' }}
         </h1>
-        <button type="button" class="btn-close" (click)="close.emit()"></button>
+        <button type="button" class="btn-close" (click)="goBackModal()"></button>
       </div>
 
       <div class="modal-body">
@@ -40,13 +39,16 @@
             <button type="button" class="btn btn-outline-secondary" (click)="openNewPhaseModal()">
               + Criar Nova Etapa
             </button>
+            <button *ngIf="!editing" type="button" class="btn btn-success mt-2" (click)="openConfirmCreateTemplate()">
+              Salvar template
+            </button>
           </div>
         </div>
 
       </div>
 
       <div class="modal-footer">
-        <button *ngIf="returnToProjectConfirm" type="button" class="btn btn-secondary" (click)="goBackModal()">
+        <button type="button" class="btn btn-secondary" (click)="goBackModal()">
           Voltar
         </button>
 
@@ -62,14 +64,12 @@
   </div>
 </div>
 
-<!-- MODAIS INTERNAS -->
 <app-new-phase-template-modal [show]="showNewPhaseModal" (close)="onCloseNewPhaseModal()"
   (save)="onSaveNewPhase($event)">
 </app-new-phase-template-modal>
 
 <app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" [templatePhases]="templatePhasesForConfirm"
-  (close)="onCancelConfirm()" (created)="onProjectCreated()" (goBack)="showConfirmCreateProjectModal = true"
-  (editPhases)="editPhasesForProject()">
+  (created)="onProjectCreated()" (editPhases)="editPhasesForProject()" (goBack)="onCancelConfirm()">
 </app-confirm-create-new-project-modal>
 
 <app-confirm-create-new-template-modal [show]="showConfirmCreateTemplateModal" [selectedPhases]="projectPhases"

--- a/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.html
+++ b/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.html
@@ -68,7 +68,7 @@
   (save)="onSaveNewPhase($event)">
 </app-new-phase-template-modal>
 
-<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" [templatePhases]="templatePhasesForConfirm"
+<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" [templatePhases]="confirmProjectPhases"
   (created)="onProjectCreated()" (editPhases)="editPhasesForProject()" (goBack)="onCancelConfirm()">
 </app-confirm-create-new-project-modal>
 

--- a/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.ts
@@ -16,9 +16,9 @@ export class NewProjectTemplateModalComponent implements OnInit {
   @Input() returnToProjectConfirm = false;
 
   @Output() close = new EventEmitter<void>();
-  @Output() goBack = new EventEmitter<void>(); // Volta para a modal anterior
+  @Output() goBack = new EventEmitter<void>();
   @Output() projectCreated = new EventEmitter<void>();
-  @Output() goBackToSelect = new EventEmitter<ProjectTemplateDTO>(); // Emite template atualizado
+  @Output() goBackToSelect = new EventEmitter<ProjectTemplateDTO>();
 
   showNewPhaseModal = false;
   showConfirmCreateProjectModal = false;
@@ -81,12 +81,18 @@ export class NewProjectTemplateModalComponent implements OnInit {
   get templatePhasesForConfirm(): { name: string; duration: number }[] {
     return this.projectPhases.map(p => ({
       name: p.name,
-      duration: p.defaultDurationDays ?? 1
+      duration: p.defaultDurationDays ?? 1 
     }));
   }
 
   openConfirmCreateProject() {
     this.showConfirmCreateProjectModal = true;
+    this.show = false;
+  }
+
+  openConfirmCreateTemplate() {
+    this.showConfirmCreateTemplateModal = true;
+    this.show = false;
   }
 
   onCancelConfirm() {
@@ -101,29 +107,29 @@ export class NewProjectTemplateModalComponent implements OnInit {
   }
 
   editPhasesForProject() {
-    this.returnToProjectConfirm = true;
-    this.editing = true;
     this.show = true;
     this.showConfirmCreateProjectModal = false;
   }
 
   saveTemplate() {
-    const updatedTemplate: ProjectTemplateDTO = {
-      name: 'Template Temporário',
-      phases: this.projectPhases,
-      id: undefined,
-      description: undefined,
-      createdBy: undefined,
-      isDefault: false
-    };
-
-    this.goBackToSelect.emit(updatedTemplate);
-
     this.showNewPhaseModal = false;
     this.showConfirmCreateTemplateModal = false;
     this.show = false;
     this.editing = false;
+
+    if (this.projectPhases.length > 0) {
+      const tempTemplate: ProjectTemplateDTO = {
+        name: 'Template Temporário',
+        phases: this.projectPhases,
+        id: undefined,
+        createdBy: this.currentUserId,
+        isDefault: false,
+        description: ''
+      };
+      this.goBackToSelect.emit(tempTemplate);
+    }
   }
+
 
   onTemplateSaved(template: ProjectTemplateDTO) {
     this.showConfirmCreateTemplateModal = false;
@@ -135,6 +141,5 @@ export class NewProjectTemplateModalComponent implements OnInit {
   onCancelConfirmTemplate() {
     this.showConfirmCreateTemplateModal = false;
     this.show = true;
-    this.editing = false;
   }
 }

--- a/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.ts
@@ -1,57 +1,53 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { TemplateService } from '../../core/services/template.service';
+import { PhaseTemplateDTO, ProjectTemplateDTO } from '../../core/models/project-template.model';
 
 @Component({
   selector: 'app-new-project-template-modal',
   templateUrl: './new-project-template-modal.component.html',
   styleUrls: ['./new-project-template-modal.component.css']
 })
-export class NewProjectTemplateModalComponent {
+export class NewProjectTemplateModalComponent implements OnInit {
   @Input() show = false;
+  @Input() editing = false;
   @Input() currentUserId!: number;
   @Input() currentUserName!: string;
+  @Input() projectPhases: PhaseTemplateDTO[] = [];
+  @Input() returnToProjectConfirm = false;
 
   @Output() close = new EventEmitter<void>();
-  @Output() goBackToSelect = new EventEmitter<void>();
+  @Output() goBack = new EventEmitter<void>(); // Volta para a modal anterior
   @Output() projectCreated = new EventEmitter<void>();
+  @Output() goBackToSelect = new EventEmitter<ProjectTemplateDTO>(); // Emite template atualizado
 
+  showNewPhaseModal = false;
   showConfirmCreateProjectModal = false;
   showConfirmCreateTemplateModal = false;
+
+  otherPhases: PhaseTemplateDTO[] = [];
+
+  constructor(private templateService: TemplateService) { }
+
+  ngOnInit(): void {
+    this.loadPhaseTemplates();
+  }
+
+  private loadPhaseTemplates() {
+    this.templateService.getAllPhaseTemplates().subscribe(phases => {
+      this.otherPhases = phases.filter(p => !this.projectPhases.find(sel => sel.id === p.id));
+    });
+  }
 
   closeModal() {
     this.close.emit();
   }
 
-  saveTemplate() {
-    // Abre a modal de confirmação de template e oculta esta
+  goBackModal() {
     this.show = false;
-    this.showConfirmCreateTemplateModal = true;
-  }
-
-  goBack() {
-    this.goBackToSelect.emit();
-  }
-
-  openConfirmCreateProject() {
-    this.showConfirmCreateProjectModal = true;
-  }
-
-  onCancelConfirm() {
     this.showConfirmCreateProjectModal = false;
+    this.showConfirmCreateTemplateModal = false;
+    this.goBack.emit();
   }
-
-  onProjectCreated() {
-    this.showConfirmCreateProjectModal = false;
-    this.show = false;
-    this.projectCreated.emit();
-  }
-
-  onEditPhases() {
-    this.showConfirmCreateProjectModal = false; // fecha a modal de criar projeto
-    this.show = true; // abre a modal de novo template
-  }
-
-  showNewPhaseModal = false;
-  phases: { name: string; duration: number }[] = [];
 
   openNewPhaseModal() {
     this.showNewPhaseModal = true;
@@ -63,20 +59,82 @@ export class NewProjectTemplateModalComponent {
     this.show = true;
   }
 
-  onSaveNewPhase(newPhase: { name: string; duration: number }) {
-    this.phases.push(newPhase);
-    this.showNewPhaseModal = false;
+  onSaveNewPhase(newPhase: PhaseTemplateDTO) {
+    this.templateService.createPhaseTemplate(newPhase).subscribe(savedPhase => {
+      this.projectPhases.push(savedPhase);
+      this.loadPhaseTemplates();
+      this.showNewPhaseModal = false;
+      this.show = true;
+    });
   }
 
-  // 🔹 Novo: controle da modal de confirmação de template
-  onCancelConfirmTemplate() {
-    this.showConfirmCreateTemplateModal = false;
+  addPhaseToProject(phase: PhaseTemplateDTO) {
+    this.projectPhases.push(phase);
+    this.otherPhases = this.otherPhases.filter(p => p.id !== phase.id);
+  }
+
+  removePhaseFromProject(phase: PhaseTemplateDTO) {
+    this.otherPhases.push(phase);
+    this.projectPhases = this.projectPhases.filter(p => p.id !== phase.id);
+  }
+
+  get templatePhasesForConfirm(): { name: string; duration: number }[] {
+    return this.projectPhases.map(p => ({
+      name: p.name,
+      duration: p.defaultDurationDays ?? 1
+    }));
+  }
+
+  openConfirmCreateProject() {
+    this.showConfirmCreateProjectModal = true;
+  }
+
+  onCancelConfirm() {
+    this.showConfirmCreateProjectModal = false;
     this.show = true;
   }
 
-  onTemplateSaved() {
+  onProjectCreated() {
+    this.showConfirmCreateProjectModal = false;
+    this.show = false;
+    this.projectCreated.emit();
+  }
+
+  editPhasesForProject() {
+    this.returnToProjectConfirm = true;
+    this.editing = true;
+    this.show = true;
+    this.showConfirmCreateProjectModal = false;
+  }
+
+  saveTemplate() {
+    const updatedTemplate: ProjectTemplateDTO = {
+      name: 'Template Temporário',
+      phases: this.projectPhases,
+      id: undefined,
+      description: undefined,
+      createdBy: undefined,
+      isDefault: false
+    };
+
+    this.goBackToSelect.emit(updatedTemplate);
+
+    this.showNewPhaseModal = false;
     this.showConfirmCreateTemplateModal = false;
     this.show = false;
-    this.goBackToSelect.emit();
+    this.editing = false;
+  }
+
+  onTemplateSaved(template: ProjectTemplateDTO) {
+    this.showConfirmCreateTemplateModal = false;
+    this.show = false;
+    this.editing = false;
+    this.goBackToSelect.emit(template);
+  }
+
+  onCancelConfirmTemplate() {
+    this.showConfirmCreateTemplateModal = false;
+    this.show = true;
+    this.editing = false;
   }
 }

--- a/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/new-project-template-modal/new-project-template-modal.component.ts
@@ -25,6 +25,7 @@ export class NewProjectTemplateModalComponent implements OnInit {
   showConfirmCreateTemplateModal = false;
 
   otherPhases: PhaseTemplateDTO[] = [];
+  confirmProjectPhases: { name: string; duration: number }[] = [];
 
   constructor(private templateService: TemplateService) { }
 
@@ -81,11 +82,22 @@ export class NewProjectTemplateModalComponent implements OnInit {
   get templatePhasesForConfirm(): { name: string; duration: number }[] {
     return this.projectPhases.map(p => ({
       name: p.name,
-      duration: p.defaultDurationDays ?? 1 
+      duration: p.defaultDurationDays ?? 1
     }));
   }
 
   openConfirmCreateProject() {
+    if (!this.editing && this.projectPhases.length === 0) {
+      alert("Escolha pelo menos uma etapa antes de criar o projeto.");
+      return;
+    }
+
+    // se nao tem template, cria array temporário com as etapas selecionadas pelo usuário
+    this.confirmProjectPhases = this.projectPhases.map(p => ({
+      name: p.name,
+      duration: p.defaultDurationDays ?? 1
+    }));
+
     this.showConfirmCreateProjectModal = true;
     this.show = false;
   }

--- a/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.html
+++ b/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.html
@@ -27,52 +27,14 @@
                 </div>
               </div>
 
-              <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+              <!-- Templates existentes -->
+              <div class="col-12 col-sm-6 col-md-4 col-lg-3" *ngFor="let template of projectTemplates">
                 <div class="card template-card h-100 text-center border-3 bc-archspot-samambaia">
                   <div class="card-body d-flex align-items-center justify-content-center">
-                    <h6 class="card-title mb-0">Projeto Arquitetônico</h6>
+                    <h6 class="card-title mb-0">{{ template.name }}</h6>
                   </div>
                   <div class="card-footer bg-transparent border-0 d-grid">
-                    <button class="btn btn-success stretched-link" (click)="openConfirmCreateProject()">
-                      Criar
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <div class="col-12 col-sm-6 col-md-4 col-lg-3">
-                <div class="card template-card h-100 text-center border-3 bc-archspot-samambaia">
-                  <div class="card-body d-flex align-items-center justify-content-center">
-                    <h6 class="card-title mb-0">Projeto de Interiores</h6>
-                  </div>
-                  <div class="card-footer bg-transparent border-0 d-grid">
-                    <button class="btn btn-success stretched-link" (click)="openConfirmCreateProject()">
-                      Criar
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <div class="col-12 col-sm-6 col-md-4 col-lg-3">
-                <div class="card template-card h-100 text-center border-3 bc-archspot-samambaia">
-                  <div class="card-body d-flex align-items-center justify-content-center">
-                    <h6 class="card-title mb-0">Projeto Comercial</h6>
-                  </div>
-                  <div class="card-footer bg-transparent border-0 d-grid">
-                    <button class="btn btn-success stretched-link" (click)="openConfirmCreateProject()">
-                      Criar
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <div class="col-12 col-sm-6 col-md-4 col-lg-3">
-                <div class="card template-card h-100 text-center border-3 bc-archspot-samambaia">
-                  <div class="card-body d-flex align-items-center justify-content-center">
-                    <h6 class="card-title mb-0">Reforma</h6>
-                  </div>
-                  <div class="card-footer bg-transparent border-0 d-grid">
-                    <button class="btn btn-success stretched-link" (click)="openConfirmCreateProject()">
+                    <button class="btn btn-success stretched-link" (click)="selectTemplate(template)">
                       Criar
                     </button>
                   </div>
@@ -86,11 +48,13 @@
   </div>
 </div>
 
-<app-new-project-template-modal [show]="showNewTemplateModal" [currentUserId]="currentUserId"
-  [currentUserName]="currentUserName" (close)="showNewTemplateModal = false"
-  (goBackToSelect)="showNewTemplateModal = false; show = true">
+<!-- Modais secundárias -->
+<app-new-project-template-modal [show]="showNewTemplateModal" [editing]="editing" [projectPhases]="projectPhases"
+  [returnToProjectConfirm]="returnToProjectConfirm" (goBack)="handleGoBack()" (close)="showNewTemplateModal = false"
+  (goBackToSelect)="onNewTemplateSaved($event)" (projectCreated)="projectCreated.emit()">
 </app-new-project-template-modal>
 
-<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" (close)="onCancelConfirm()"
-  (created)="onProjectCreated()" (editPhases)="onEditPhases()">
+<app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" [templatePhases]="selectedTemplatePhases"
+  [templateName]="selectedTemplate?.name || ''" (goBack)="showConfirmCreateProjectModal = false"
+  (editPhases)="editPhases($event)" (created)="onProjectCreated()" (close)="showConfirmCreateProjectModal = false">
 </app-confirm-create-new-project-modal>

--- a/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.html
+++ b/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.html
@@ -1,4 +1,3 @@
-<!-- CARD INICIAL COM TEMPLATES -->
 <div class="modal-overlay" *ngIf="show">
   <div class="modal fade show d-block" tabindex="-1">
     <div class="modal-dialog modal-lg modal-dialog-centered">
@@ -27,7 +26,6 @@
                 </div>
               </div>
 
-              <!-- Templates existentes -->
               <div class="col-12 col-sm-6 col-md-4 col-lg-3" *ngFor="let template of projectTemplates">
                 <div class="card template-card h-100 text-center border-3 bc-archspot-samambaia">
                   <div class="card-body d-flex align-items-center justify-content-center">
@@ -48,13 +46,12 @@
   </div>
 </div>
 
-<!-- Modais secundárias -->
 <app-new-project-template-modal [show]="showNewTemplateModal" [editing]="editing" [projectPhases]="projectPhases"
-  [returnToProjectConfirm]="returnToProjectConfirm" (goBack)="handleGoBack()" (close)="showNewTemplateModal = false"
+  [returnToProjectConfirm]="returnToProjectConfirm" (goBack)="handleGoBack()" (close)="handleGoBack()"
   (goBackToSelect)="onNewTemplateSaved($event)" (projectCreated)="projectCreated.emit()">
 </app-new-project-template-modal>
 
 <app-confirm-create-new-project-modal [show]="showConfirmCreateProjectModal" [templatePhases]="selectedTemplatePhases"
-  [templateName]="selectedTemplate?.name || ''" (goBack)="showConfirmCreateProjectModal = false"
-  (editPhases)="editPhases($event)" (created)="onProjectCreated()" (close)="showConfirmCreateProjectModal = false">
+  [templateId]="selectedTemplate?.id" [templateName]="selectedTemplate?.name || ''" (goBack)="handleGoBack()"
+  (editPhases)="editPhases($event)" (created)="onProjectCreated()" (close)="handleGoBack()">
 </app-confirm-create-new-project-modal>

--- a/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.ts
@@ -1,34 +1,93 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { TemplateService } from '../../core/services/template.service';
+import { PhaseTemplateDTO, ProjectTemplateDTO } from '../../core/models/project-template.model';
+
+interface Etapa {
+  nome: string;
+  duracao?: number;
+}
 
 @Component({
   selector: 'app-select-template-modal',
   templateUrl: './select-template-modal.component.html',
   styleUrls: ['./select-template-modal.component.css']
 })
-export class SelectTemplateModalComponent {
+export class SelectTemplateModalComponent implements OnInit {
   @Input() show = false;
   @Input() currentUserId!: number;
   @Input() currentUserName!: string;
-
   @Output() close = new EventEmitter<void>();
   @Output() projectCreated = new EventEmitter<void>();
+
+  editing = false;
+  projectPhases: PhaseTemplateDTO[] = [];
+  projectTemplates: ProjectTemplateDTO[] = [];
+  selectedTemplate?: ProjectTemplateDTO;
+  selectedTemplatePhases: { name: string; duration: number }[] = [];
+  returnToProjectConfirm = false;
 
   showNewTemplateModal = false;
   showConfirmCreateProjectModal = false;
 
-  openNewTemplate() {
-    this.show = false;
-    this.showNewTemplateModal = true;
+  constructor(private templateService: TemplateService) { }
+
+  ngOnInit(): void {
+    this.loadProjectTemplates();
   }
 
-  openConfirmCreateProject() {
+  private loadProjectTemplates() {
+    this.templateService.getProjectTemplates().subscribe({
+      next: templates => this.projectTemplates = templates,
+      error: err => console.error('Erro ao carregar templates:', err)
+    });
+  }
+
+  openNewTemplate(existingPhases?: { nome: string; duracao?: number }[]) {
     this.show = false;
+    this.showNewTemplateModal = true;
+    this.editing = false;
+
+    if (existingPhases) {
+      this.projectPhases = existingPhases.map(p => ({
+        name: p.nome,
+        defaultDurationDays: p.duracao
+      }));
+    }
+  }
+
+  selectTemplate(template: ProjectTemplateDTO) {
+    this.selectedTemplate = template;
+    this.selectedTemplatePhases = template.phases?.map(p => ({
+      name: p.name,
+      duration: p.defaultDurationDays ?? 1
+    })) || [];
+
     this.showConfirmCreateProjectModal = true;
+    this.show = false;
   }
 
-  onEditPhases() {
-    this.showConfirmCreateProjectModal = false;
+  editPhases(etapas: Etapa[]) {
+    this.projectPhases = etapas.map(e => ({
+      name: e.nome,
+      defaultDurationDays: e.duracao
+    }));
+
+    this.editing = true;
     this.showNewTemplateModal = true;
+    this.showConfirmCreateProjectModal = false;
+    this.returnToProjectConfirm = true;
+  }
+
+  /** Chamado pelo filho ao clicar em "Voltar" */
+  handleGoBack() {
+    if (this.returnToProjectConfirm) {
+      // Volta para a confirmação de projeto
+      this.showConfirmCreateProjectModal = true;
+    } else {
+      // Volta para a tela de seleção
+      this.show = true;
+    }
+    this.showNewTemplateModal = false;
   }
 
   onCancelConfirm() {
@@ -37,8 +96,30 @@ export class SelectTemplateModalComponent {
   }
 
   onProjectCreated() {
-    this.showConfirmCreateProjectModal = false;
-    this.show = false;
+    this.resetModal();
     this.projectCreated.emit();
+  }
+
+  onNewTemplateSaved(savedTemplate: ProjectTemplateDTO) {
+    this.showNewTemplateModal = false;
+
+    this.selectedTemplatePhases = savedTemplate.phases?.map(p => ({
+      name: p.name,
+      duration: p.defaultDurationDays ?? 1
+    })) || [];
+
+    this.showConfirmCreateProjectModal = true;
+    this.editing = false;
+  }
+
+  private resetModal() {
+    this.show = false;
+    this.showNewTemplateModal = false;
+    this.showConfirmCreateProjectModal = false;
+    this.editing = false;
+    this.returnToProjectConfirm = false;
+    this.selectedTemplate = undefined;
+    this.projectPhases = [];
+    this.selectedTemplatePhases = [];
   }
 }

--- a/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.ts
@@ -113,7 +113,8 @@ export class SelectTemplateModalComponent implements OnInit {
       name: p.name,
       duration: p.defaultDurationDays ?? 1
     })) || [];
-    this.showConfirmCreateProjectModal = true;
+
+    this.show = true;
   }
 
   private resetModal() {

--- a/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.ts
+++ b/archspot-angular/src/app/templates/select-template-modal/select-template-modal.component.ts
@@ -37,7 +37,17 @@ export class SelectTemplateModalComponent implements OnInit {
 
   private loadProjectTemplates() {
     this.templateService.getProjectTemplates().subscribe({
-      next: templates => this.projectTemplates = templates,
+      next: templates => {
+        const userId = this.currentUserId;
+
+        const filtered = templates.filter((t, index, self) => {
+          if (!t.isDefault) return true;
+          const cloneExists = self.some(other => !other.isDefault && other.name === t.name && other.createdBy === userId);
+          return !cloneExists;
+        });
+
+        this.projectTemplates = filtered;
+      },
       error: err => console.error('Erro ao carregar templates:', err)
     });
   }
@@ -78,16 +88,11 @@ export class SelectTemplateModalComponent implements OnInit {
     this.returnToProjectConfirm = true;
   }
 
-  /** Chamado pelo filho ao clicar em "Voltar" */
   handleGoBack() {
-    if (this.returnToProjectConfirm) {
-      // Volta para a confirmação de projeto
-      this.showConfirmCreateProjectModal = true;
-    } else {
-      // Volta para a tela de seleção
-      this.show = true;
-    }
+    this.showConfirmCreateProjectModal = false;
+    this.show = true;
     this.showNewTemplateModal = false;
+    this.returnToProjectConfirm = false;
   }
 
   onCancelConfirm() {
@@ -102,14 +107,13 @@ export class SelectTemplateModalComponent implements OnInit {
 
   onNewTemplateSaved(savedTemplate: ProjectTemplateDTO) {
     this.showNewTemplateModal = false;
-
+    this.projectTemplates.push(savedTemplate);
+    this.selectedTemplate = savedTemplate;
     this.selectedTemplatePhases = savedTemplate.phases?.map(p => ({
       name: p.name,
       duration: p.defaultDurationDays ?? 1
     })) || [];
-
     this.showConfirmCreateProjectModal = true;
-    this.editing = false;
   }
 
   private resetModal() {


### PR DESCRIPTION
closes #118 - Carregar templates nos modais

<h2>Fixs</h2>

- Numeração do projeto retirada do sidebar menu;
- "Integrantes" em Sobre trocado para "Desenvolvedores";
- Correção na edição do valor da parcela;
- Na barra de cronograma, quando a atividade se iniciar em atraso, a bolinha deve ficar em vermelho (quando não iniciada, deve-se permanecer cinza)

<h2>Pontos a corrigir</h2>

- FRONT: Ao editar etapas em um template de projeto existente, clicar em uma etapa acaba retirando todas da lista "etapas do projeto"
- GPT sugeriu uma mudança no TemplateService (findAllPhaseTemplates e findAllProjectTemplates), porque não estava puxando os templates e etapas existentes, e ele insistiu que deveria mudar no back-end.. verificar 